### PR TITLE
feat: added instance_class to ignore_changes in rds

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -25,7 +25,8 @@ resource "aws_db_instance" "this" {
 
   lifecycle {
     ignore_changes = [
-      replicate_source_db
+      replicate_source_db,
+      instance_class,
     ]
   }
 }


### PR DESCRIPTION
#### Changes

Added `instance_class` to `ignore_changes` in the rds resource. This is done to mitigate destroying the RDS when the `instance_class` is changed.